### PR TITLE
Make SailthruResponseError inherit from Exception + lint code

### DIFF
--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
-
 import hashlib
 from sailthru_http import sailthru_http_request
 
-try: import simplejson as json
-except ImportError: import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 
 def extract_params(params):
     """
@@ -21,6 +22,7 @@ def extract_params(params):
         values.append(params)
     return values
 
+
 def get_signature_string(params, secret):
     """
     Returns the unhashed signature string (secret + sorted list of param values) for an API call.
@@ -32,6 +34,7 @@ def get_signature_string(params, secret):
         str_list.append(str(item))
     str_list.sort()
     return secret + "".join(str_list)
+
 
 def get_signature_hash(params, secret):
     """
@@ -61,7 +64,8 @@ class SailthruClient(object):
     def __init__(self, api_key, secret, api_url=None):
         self.api_key = api_key
         self.secret = secret
-        self.api_url = api_url if (api_url is not None) else 'https://api.sailthru.com'
+        self.api_url = api_url if (
+            api_url is not None) else 'https://api.sailthru.com'
         self.user_agent = 'Sailthru API Python Client'
 
     def send(self, template, email, _vars=None, options=None, schedule_time=None):
@@ -331,7 +335,7 @@ class SailthruClient(object):
         """
         Get metadata for all lists
         """
-        data = {'list': ''} #blank list
+        data = {'list': ''}  # blank list
         return self.api_get('list', data)
 
     def save_list(self, list, emails):
@@ -405,7 +409,8 @@ class SailthruClient(object):
             alert_options['match']['type'] = 'shoes'
             alert_options['min']['price'] = 20000 #cents
             alert_options['tags'] = ['red', 'blue', 'green']
-            response = client.save_alert(email, type, template, when, alert_options)
+            response = client.save_alert(
+                email, type, template, when, alert_options)
 
         @param email: Email value
         @param type: daily|weekly|realtime
@@ -568,7 +573,7 @@ class SailthruClient(object):
         """
         if type(post_params) is dict:
             required_params = ['action', 'email', 'sig']
-            if self.check_for_valid_postback_actions(required_params, post_params ) is False:
+            if self.check_for_valid_postback_actions(required_params, post_params) is False:
                 return False
         else:
             return False
@@ -651,8 +656,8 @@ class SailthruClient(object):
         json_payload = self._prepare_json_payload(data)
 
         print data
-        
-        return self._http_request(self.api_url+'/'+action, json_payload, "POST", binary_data)
+
+        return self._http_request(self.api_url + '/' + action, json_payload, "POST", binary_data)
 
     def api_delete(self, action, data):
         """
@@ -666,8 +671,8 @@ class SailthruClient(object):
         """
         Make Request to Sailthru API with given data and api key, format and signature hash
         """
-        return self._http_request(self.api_url+'/'+action, self._prepare_json_payload(data), request_type)
-    
+        return self._http_request(self.api_url + '/' + action, self._prepare_json_payload(data), request_type)
+
     def _http_request(self, url, data, method, file_data=None):
         file_data = file_data or {}
         return sailthru_http_request(url, data, method, file_data)

--- a/sailthru/sailthru_http.py
+++ b/sailthru/sailthru_http.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
-
 import requests
 from sailthru.sailthru_error import SailthruClientError
 from sailthru.sailthru_response import SailthruResponse
+
 
 def flatten_nested_hash(hash_table):
     """
@@ -10,23 +9,24 @@ def flatten_nested_hash(hash_table):
     """
     def flatten(hash_table, brackets=True):
         f = {}
-        for key,value in hash_table.items():
+        for key, value in hash_table.items():
             _key = '[' + str(key) + ']' if (brackets == True) else str(key)
             if type(value) is dict:
-                for k,v in flatten(value).items():
+                for k, v in flatten(value).items():
                     f[_key + k] = v
             elif type(value) is list:
                 temp_hash = {}
-                for i,v in enumerate(value):
+                for i, v in enumerate(value):
                     temp_hash[str(i)] = v
-                for k,v in flatten(temp_hash).items():
-                    f[ _key + k] = v
+                for k, v in flatten(temp_hash).items():
+                    f[_key + k] = v
             else:
                 f[_key] = value
         return f
     return flatten(hash_table, False)
 
-def sailthru_http_request(url, data, method, file_data = None):
+
+def sailthru_http_request(url, data, method, file_data=None):
     """
     Perform an HTTP GET / POST / DELETE request
     """
@@ -36,12 +36,13 @@ def sailthru_http_request(url, data, method, file_data = None):
     params = data if method != 'POST' else None
     body = data if method == 'POST' else None
     try:
-	headers = { 'User-Agent': 'Sailthru API Python Client' }
-        response = requests.request(method, url, params = params, data = data, files = file_data, headers = headers)
+        headers = {'User-Agent': 'Sailthru API Python Client'}
+        response = requests.request(method, url, params=params, data=data,
+                                    files=file_data, headers=headers)
         if response.status_code is None:
             raise SailthruClientError(response.error)
         return SailthruResponse(response)
     except requests.HTTPError, e:
-	raise SailthruClientError(str(e))
+        raise SailthruClientError(str(e))
     except requests.RequestException, e:
-	raise SailthruClientError(str(e))
+        raise SailthruClientError(str(e))

--- a/sailthru/sailthru_response.py
+++ b/sailthru/sailthru_response.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
-
 try:
     import simplejson as json
 except ImportError:
     import json
+
 
 class SailthruResponse(object):
     def __init__(self, response):
@@ -18,7 +17,7 @@ class SailthruResponse(object):
     def is_ok(self):
         return self.json_error is not None and not "error" in self.json.keys()
 
-    def get_body(self, as_dictionary = True):
+    def get_body(self, as_dictionary=True):
         if as_dictionary is True:
             return self.json
         else:


### PR DESCRIPTION
This is a backwards incompatible change
- SailthruResponseError 
  - inherit from Exception
  - remove get_message and get_error_code methods
- code linting
