### PR TITLE
Added a timeout to the API request

### DIFF
--- a/sailthru/sailthru_http.py
+++ b/sailthru/sailthru_http.py
@@ -37,7 +37,7 @@ def sailthru_http_request(url, data, method, file_data = None):
     body = data if method == 'POST' else None
     try:
 	headers = { 'User-Agent': 'Sailthru API Python Client' }
-        response = requests.request(method, url, params = params, data = data, files = file_data, headers = headers)
+        response = requests.request(method, url, params = params, data = data, files = file_data, headers = headers, timeout = 10)
         if response.status_code is None:
             raise SailthruClientError(response.error)
         return SailthruResponse(response)


### PR DESCRIPTION
At GameChanger, we've observed it's possible for our email queue processors to all simultaneously hang. When we restart them they are able to resume processing fine.

We believe that the lack of a timeout on the HTTP request to the Sailthru API is causing this request to never return in the event of a temporary network partition, causing the hanging of our processes.

This adds a reasonable timeout of 10 seconds to ensure that processes are able to recover.

cc @byels
