### PR TITLE
Feature/venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+
+# Virtualenv
+venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+init:
+	virtualenv --no-site-packages venv
+	source venv/bin/activate && pip install -r requirements.txt
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test
+
 init:
 	virtualenv --no-site-packages venv
 	source venv/bin/activate && pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,5 @@ init:
 	virtualenv --no-site-packages venv
 	source venv/bin/activate && pip install -r requirements.txt
 
+test:
+	nosetests -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
-simplejson
-nose
+requests==2.5.0
+simplejson==3.6.5
+nose==1.3.4
+mock==1.0.1


### PR DESCRIPTION
Added support for virtualenv. This is somewhat opinionated, so let me know if it should be changed or isn't valid:

* Virtualenv is stored in `venv` rather than `.`. IMO it's better for keeping the root folder uncluttered, but others would disagree.
* Set specific dependency versions to prevent bugs from changing libraries.
* Added a requirement for mock, which was needed for the tests to pass but wasn't specified as a requirement.
* Added a `Makefile`.
