### PR TITLE
Fix function signature of save_template (closes #55)

### DIFF
--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -328,7 +328,7 @@ class SailthruClient(object):
         data = {'template': template_name}
         return self.api_delete('template', data)
 
-    def save_template(self, template, **template_fields):
+    def save_template(self, template, template_fields=None):
         data = {'template': template}
         if template_fields:
             data.update(template_fields)


### PR DESCRIPTION
Reverts bug introduced in 4613d53c with release 2.2.1. See https://github.com/sailthru/sailthru-python-client/issues/55