### PR TITLE
decoding response content so it can be json loaded in python 3 without simplejson

### DIFF
--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -569,7 +569,7 @@ class SailthruClient(object):
         send_response = self.get_send(post_params['send_id'])
 
         try:
-            send_body = send_response.get_body()
+            send_body = send_response.get_body(as_dictionary=False)
             send_json = json.loads(send_body)
             if 'email' not in send_body:
                 return False

--- a/sailthru/sailthru_response.py
+++ b/sailthru/sailthru_response.py
@@ -11,7 +11,7 @@ class SailthruResponse(object):
         self.json_error = None
 
         try:
-            self.json = json.loads(response.content)
+            self.json = json.loads(response.content.decode())
         except ValueError as e:
             self.json = None
             self.json_error = str(e)
@@ -23,7 +23,7 @@ class SailthruResponse(object):
         if as_dictionary:
             return self.json
         else:
-            return self.response.content
+            return self.response.content.decode()
 
     def get_response(self):
         return self.response


### PR DESCRIPTION
In Python 3, without simplejson, a successful `api_post` call returns the following exception:
`TypeError: the JSON object must be str, not 'bytes'`.  The reason seems to be that `response.content` is a bytes literal, which need to be decoded before being passed in to `json.loads`.

`simplejson.loads` seems to handle byte literals, but unfortunately, simplejson conflicts with some of the other third party libraries we're using.