### PR TITLE
Add request timeout argument

### DIFF
--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -55,7 +55,7 @@ class SailthruClient(object):
         client = SailthruClient(api_key, api_secret)
     """
 
-    def __init__(self, api_key, secret, api_url=None, request_timeout=None):
+    def __init__(self, api_key, secret, api_url=None, request_timeout=10):
         self.api_key = api_key
         self.secret = secret
         self.api_url = api_url if api_url else 'https://api.sailthru.com'

--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -55,10 +55,11 @@ class SailthruClient(object):
         client = SailthruClient(api_key, api_secret)
     """
 
-    def __init__(self, api_key, secret, api_url=None):
+    def __init__(self, api_key, secret, api_url=None, request_timeout=None):
         self.api_key = api_key
         self.secret = secret
         self.api_url = api_url if api_url else 'https://api.sailthru.com'
+        self.request_timeout = request_timeout
         self.last_rate_limit_info = {}
 
     def send(self, template, email, _vars=None, options=None, schedule_time=None, limit=None):
@@ -762,7 +763,7 @@ class SailthruClient(object):
     def _http_request(self, action, data, method, file_data=None, headers=None):
         url = self.api_url + '/' + action
         file_data = file_data or {}
-        response = sailthru_http_request(url, data, method, file_data, headers)
+        response = sailthru_http_request(url, data, method, file_data, headers, self.request_timeout)
         if (action in self.last_rate_limit_info):
             self.last_rate_limit_info[action][method] = response.get_rate_limit_headers()
         else:

--- a/sailthru/sailthru_http.py
+++ b/sailthru/sailthru_http.py
@@ -27,7 +27,7 @@ def flatten_nested_hash(hash_table):
         return f
     return flatten(hash_table, False)
 
-def sailthru_http_request(url, data, method, file_data=None, headers=None):
+def sailthru_http_request(url, data, method, file_data=None, headers=None, request_timeout=None):
     """
     Perform an HTTP GET / POST / DELETE request
     """
@@ -35,13 +35,14 @@ def sailthru_http_request(url, data, method, file_data=None, headers=None):
     method = method.upper()
     params, data = (None, data) if method == 'POST' else (data, None)
     sailthru_headers = {'User-Agent': 'Sailthru API Python Client %s; Python Version: %s' % ('2.3.4', platform.python_version())}
+    request_timeout = request_timeout if request_timeout is not None else 10
     if headers and isinstance(headers, dict):
         for key, value in sailthru_headers.items():
             headers[key] = value
     else:
         headers = sailthru_headers
     try:
-        response = requests.request(method, url, params=params, data=data, files=file_data, headers=headers, timeout=10)
+        response = requests.request(method, url, params=params, data=data, files=file_data, headers=headers, timeout=request_timeout)
         return SailthruResponse(response)
     except requests.HTTPError as e:
         raise SailthruClientError(str(e))

--- a/sailthru/sailthru_http.py
+++ b/sailthru/sailthru_http.py
@@ -27,7 +27,7 @@ def flatten_nested_hash(hash_table):
         return f
     return flatten(hash_table, False)
 
-def sailthru_http_request(url, data, method, file_data=None, headers=None, request_timeout=None):
+def sailthru_http_request(url, data, method, file_data=None, headers=None, request_timeout=10):
     """
     Perform an HTTP GET / POST / DELETE request
     """
@@ -35,7 +35,6 @@ def sailthru_http_request(url, data, method, file_data=None, headers=None, reque
     method = method.upper()
     params, data = (None, data) if method == 'POST' else (data, None)
     sailthru_headers = {'User-Agent': 'Sailthru API Python Client %s; Python Version: %s' % ('2.3.4', platform.python_version())}
-    request_timeout = request_timeout if request_timeout is not None else 10
     if headers and isinstance(headers, dict):
         for key, value in sailthru_headers.items():
             headers[key] = value


### PR DESCRIPTION
* Added argument to SailthruClient constructor that allows a user to set the request timeout to a value other than 10. If none is set then we use the default of 10 as set currently