### PR TITLE
Add inventory param to push_content function

### DIFF
--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -386,7 +386,7 @@ class SailthruClient(object):
                      description=None, location=None, price=None,
                      tags=None,
                      author=None, site_name=None,
-                     spider=None, vars=None):
+                     spider=None, vars=None, inventory=None):
 
         """
         Push a new piece of content to Sailthru.
@@ -407,6 +407,7 @@ class SailthruClient(object):
         @param site_name: site name for the content
         @param spider: truthy value to force respidering content
         @param vars: replaceable vars dictionary
+        @param inventory: integer value indicating current item inventory
 
         """
         vars = vars or {}
@@ -422,6 +423,8 @@ class SailthruClient(object):
             data['location'] = date
         if price is not None:
             data['price'] = price
+        if data['inventory'] is not None:
+            data['inventory'] = inventory
         if description is not None:
             data['description'] = description
         if site_name is not None:

--- a/sailthru/sailthru_client.py
+++ b/sailthru/sailthru_client.py
@@ -423,7 +423,7 @@ class SailthruClient(object):
             data['location'] = date
         if price is not None:
             data['price'] = price
-        if data['inventory'] is not None:
+        if inventory is not None:
             data['inventory'] = inventory
         if description is not None:
             data['description'] = description


### PR DESCRIPTION
Hearst has been implementing ecomm use cases and noted that inventory is not available in our Python library's push_content() function. This update adds that param to the function.